### PR TITLE
Allow 100% packet loss or corruption

### DIFF
--- a/tcconfig/traffic_control.py
+++ b/tcconfig/traffic_control.py
@@ -59,13 +59,13 @@ class TrafficControl(object):
     __IN_DEVICE_QDISC_MINOR_ID = 3
 
     __MIN_PACKET_LOSS_RATE = 0  # [%]
-    __MAX_PACKET_LOSS_RATE = 99  # [%]
+    __MAX_PACKET_LOSS_RATE = 100  # [%]
 
     __MIN_LATENCY_MS = 0  # [millisecond]
     __MAX_LATENCY_MS = 10000  # [millisecond]
 
     __MIN_CORRUPTION_RATE = 0  # [%]
-    __MAX_CORRUPTION_RATE = 99  # [%]
+    __MAX_CORRUPTION_RATE = 100  # [%]
 
     __MIN_BUFFER_BYTE = 1600
 

--- a/test/test_traffic_control.py
+++ b/test/test_traffic_control.py
@@ -83,8 +83,8 @@ class Test_TrafficControl_validate(object):
                 [TrafficDirection.OUTGOING],
                 [None, 0, 10000],  # delay
                 [None, 0, 10000],  # delay_distro
-                [None, 0, MIN_PACKET_LOSS, 99],  # loss
-                [None, 0, 99],  # corrupt
+                [None, 0, MIN_PACKET_LOSS, 100],  # loss
+                [None, 0, 100],  # corrupt
                 [
                     None,
                     "",
@@ -128,10 +128,10 @@ class Test_TrafficControl_validate(object):
         [{"latency_distro_ms": 10001}, ValueError],
 
         [{"packet_loss_rate": -0.1}, ValueError],
-        [{"packet_loss_rate": 99.1}, ValueError],
+        [{"packet_loss_rate": 100.1}, ValueError],
 
         [{"curruption_rate": -0.1}, ValueError],
-        [{"curruption_rate": 99.1}, ValueError],
+        [{"curruption_rate": 100.1}, ValueError],
 
         [{"network": "192.168.0."}, ValueError],
         [{"network": "192.168.0.256"}, ValueError],


### PR DESCRIPTION
I wanted to use tcconfig to simulate loss of connectivity to another machine, by setting

`--loss 100 --network <IP>`.

This failed, due to a max packet loss rate of 99%. However, `tc` accepts 100% and appears to work fine, so I think a 100% limit is more useful. 

I also changed max corruption rate for the sake of consistency.

😃 