### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,12 @@ tcconfig
 
 .. image:: https://img.shields.io/pypi/pyversions/tcconfig.svg
    :target: https://pypi.python.org/pypi/tcconfig
+
 .. image:: https://travis-ci.org/thombashi/tcconfig.svg?branch=master
    :target: https://travis-ci.org/thombashi/tcconfig
+
+.. image:: https://img.shields.io/github/stars/thombashi/tcconfig.svg?style=social&label=Star
+   :target: https://github.com/thombashi/tcconfig
 
 Summary
 -------
@@ -88,8 +92,7 @@ e.g. Specify the IP network and port of traffic control
 Delete traffic control (``tcdel`` command)
 ------------------------------------------
 
-``tcdel`` is a command to delete traffic control from a network
-interface (device).
+``tcdel`` is a command to delete traffic shaping rules from a network interface (device).
 
 e.g. Delete traffic control of eth0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -142,14 +145,25 @@ http://tcconfig.rtfd.io/en/latest/pages/usage/index.html
 Installation
 ============
 
-Install via pip
----------------
-``tcconfig`` can be installed via
-`pip <https://pip.pypa.io/en/stable/installing/>`__ (Python package manager).
+Installing from PyPI
+------------------------------
+``tcconfig`` can be installed from `PyPI <https://pypi.python.org/pypi>`__ via
+`pip <https://pip.pypa.io/en/stable/installing/>`__ (Python package manager) command.
 
 .. code:: console
 
     sudo pip install tcconfig
+
+
+Installing from binary
+------------------------------
+``tcconfig`` can be installed environments where cannot access to
+`PyPI <https://pypi.python.org/pypi>`__ directly:
+
+1. ``https://github.com/thombashi/tcconfig/releases/download/v0.7.0/tcconfig_wheel.tar.gz``
+2. ``tar xvf tcconfig_wheel.tar.gz``
+3. ``cd tcconfig_wheel/``
+4. ``./install.sh``
 
 
 Dependencies
@@ -157,7 +171,8 @@ Dependencies
 
 Linux packages
 --------------
-- iproute2 (required for tc command)
+- iproute2 (mandatory: required for tc command)
+- iptables (optional: required to when you use ``--iptables`` option)
 
 Linux kernel module
 ----------------------------
@@ -183,6 +198,7 @@ Optional
 
 Test dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- `allpairspy <https://github.com/thombashi/allpairspy>`__
 - `pingparsing <https://github.com/thombashi/pingparsing>`__
 - `pytest <http://pytest.org/latest/>`__
 - `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`__
@@ -201,7 +217,7 @@ Phenomenon
 `tcset` command failed with an error message `RTNETLINK answers: No such file or directory`.
 
 
-Cause and counter measures
+Solutions
 --------------------------
 The cause of this error is `sch_netem` kernel module is not loaded in your system.
 Execute the following command to solve this problem:

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ Installing from PyPI
 
 Installing from binary
 ------------------------------
-``tcconfig`` can be installed environments where cannot access to
+``tcconfig`` can be installed environments which cannot access to
 `PyPI <https://pypi.python.org/pypi>`__ directly:
 
 1. ``https://github.com/thombashi/tcconfig/releases/download/v0.7.0/tcconfig_wheel.tar.gz``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,6 @@
 Welcome to tcconfig's documentation!
 ====================================
 
-.. image:: https://img.shields.io/github/stars/thombashi/tcconfig.svg?style=social&label=Star
-   :target: https://github.com/thombashi/tcconfig
-
 .. toctree::
    :caption: Table of Contents
    :maxdepth: 3

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -13,7 +13,7 @@ Installing from PyPI
 
 Installing from binary
 ------------------------------
-``tcconfig`` can be installed environments where cannot access to 
+``tcconfig`` can be installed environments which cannot access to 
 `PyPI <https://pypi.python.org/pypi>`__ directly:
 
 1. ``https://github.com/thombashi/tcconfig/releases/download/v0.7.0/tcconfig_wheel.tar.gz``

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -13,12 +13,13 @@ Installing from PyPI
 
 Installing from binary
 ------------------------------
-``tcconfig`` can be installed without using `PyPI <https://pypi.python.org/pypi>`__:
+``tcconfig`` can be installed environments where cannot access to 
+`PyPI <https://pypi.python.org/pypi>`__ directly:
 
-    1. ``https://github.com/thombashi/tcconfig/releases/download/v0.7.0/tcconfig_wheel.tar.gz``
-    2. ``tar xvf tcconfig_wheel.tar.gz``
-    3. ``cd tcconfig_wheel/``
-    4. ``./install.sh``
+1. ``https://github.com/thombashi/tcconfig/releases/download/v0.7.0/tcconfig_wheel.tar.gz``
+2. ``tar xvf tcconfig_wheel.tar.gz``
+3. ``cd tcconfig_wheel/``
+4. ``./install.sh``
 
 
 Dependencies

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -1,14 +1,24 @@
 Installation
 ============
 
-Install via pip
----------------
-``tcconfig`` can be installed via
-`pip <https://pip.pypa.io/en/stable/installing/>`__ (Python package manager).
+Installing from PyPI
+------------------------------
+``tcconfig`` can be installed from `PyPI <https://pypi.python.org/pypi>`__ via
+`pip <https://pip.pypa.io/en/stable/installing/>`__ (Python package manager) command.
 
 .. code:: console
 
     sudo pip install tcconfig
+
+
+Installing from binary
+------------------------------
+``tcconfig`` can be installed without using `PyPI <https://pypi.python.org/pypi>`__:
+
+    1. ``https://github.com/thombashi/tcconfig/releases/download/v0.7.0/tcconfig_wheel.tar.gz``
+    2. ``tar xvf tcconfig_wheel.tar.gz``
+    3. ``cd tcconfig_wheel/``
+    4. ``./install.sh``
 
 
 Dependencies
@@ -16,7 +26,8 @@ Dependencies
 
 Linux packages
 --------------
-- iproute2 (required for tc command)
+- iproute2 (mandatory: required for tc command)
+- iptables (optional: required to when you use ``--iptables`` option)
 
 Linux kernel module
 ----------------------------
@@ -42,6 +53,7 @@ Optional
 
 Test dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- `allpairspy <https://github.com/thombashi/allpairspy>`__
 - `pingparsing <https://github.com/thombashi/pingparsing>`__
 - `pytest <http://pytest.org/latest/>`__
 - `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`__

--- a/docs/pages/introduction/badges.txt
+++ b/docs/pages/introduction/badges.txt
@@ -1,4 +1,8 @@
 .. image:: https://img.shields.io/pypi/pyversions/tcconfig.svg
    :target: https://pypi.python.org/pypi/tcconfig
+
 .. image:: https://travis-ci.org/thombashi/tcconfig.svg?branch=master
    :target: https://travis-ci.org/thombashi/tcconfig
+
+.. image:: https://img.shields.io/github/stars/thombashi/tcconfig.svg?style=social&label=Star
+   :target: https://github.com/thombashi/tcconfig

--- a/docs/pages/troubleshooting.rst
+++ b/docs/pages/troubleshooting.rst
@@ -6,7 +6,7 @@ Phenomenon
 `tcset` command failed with an error message `RTNETLINK answers: No such file or directory`.
 
 
-Cause and counter measures
+Solutions
 --------------------------
 The cause of this error is `sch_netem` kernel module is not loaded in your system.
 Execute the following command to solve this problem: 

--- a/docs/pages/usage/tcdel/header.rst
+++ b/docs/pages/usage/tcdel/header.rst
@@ -1,5 +1,4 @@
 Delete traffic control (``tcdel`` command)
 ------------------------------------------
 
-``tcdel`` is a command to delete traffic control from a network
-interface (device).
+``tcdel`` is a command to delete traffic shaping rules from a network interface (device).

--- a/docs/pages/usage/tcdel/tcdel_help.rst
+++ b/docs/pages/usage/tcdel/tcdel_help.rst
@@ -1,10 +1,15 @@
+    .. note::
+
+        ``tcdel`` will be deleted mangle tables in ``iptables``.
+        (any other tables are not affected).
+
+
 ``tcdel`` command help
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-    usage: tcdel [-h] [--version] [--logging] [--stacktrace] [--debug | --quiet]
-                 --device DEVICE
+    usage: tcdel [-h] [--version] [--debug | --quiet] --device DEVICE
 
 .. option:: tcdel command options
 
@@ -12,11 +17,8 @@
       -h, --help       show this help message and exit
       --version        show program's version number and exit
       --debug          for debug print.
-      --quiet          suppress output of execution log message.
-
-    Miscellaneous:
-      --logging        output execution log to a file (tcdel.log).
-      --stacktrace     display stack trace when an error occurred.
+      --quiet          suppress execution log messages.
 
     Traffic Control:
       --device DEVICE  network device name (e.g. eth0)
+

--- a/docs/pages/usage/tcset/advanced_usage.rst
+++ b/docs/pages/usage/tcset/advanced_usage.rst
@@ -31,3 +31,12 @@ e.g. Set 100ms +- 20ms network latency with normal distribution
 .. code-block:: console
 
     # tcset --device eth0 --delay 100 --delay-distro 20
+
+
+Multiple traffic shaping rules per interface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+    tcset --device eth0 --rate 500M --network 192.168.2.0/24
+    tcset --device eth0 --rate 100M --network 192.168.0.0/24 --add

--- a/docs/pages/usage/tcset/tcset_help.rst
+++ b/docs/pages/usage/tcset/tcset_help.rst
@@ -3,12 +3,13 @@
 
 ::
 
-    usage: tcset [-h] [--version] [--logging] [--stacktrace] [--debug | --quiet]
-                 (--device DEVICE | -f CONFIG_FILE) [--overwrite]
+    usage: tcset [-h] [--version] [--debug | --quiet]
+                 (--device DEVICE | -f CONFIG_FILE) [--overwrite | --add]
                  [--direction {outgoing,incoming}] [--rate BANDWIDTH_RATE]
                  [--delay NETWORK_LATENCY] [--delay-distro LATENCY_DISTRO_MS]
                  [--loss PACKET_LOSS_RATE] [--corrupt CORRUPTION_RATE]
-                 [--network NETWORK] [--port PORT]
+                 [--network NETWORK] [--port PORT] [--shaping-algo {tbf,htb}]
+                 [--iptables] [--src-network SRC_NETWORK]
 
 .. option:: tcset command options
 
@@ -21,24 +22,24 @@
       -f CONFIG_FILE, --config-file CONFIG_FILE
                             setting traffic controls from a configuration file.
                             output file of the tcshow.
-
-    Network Interface:
       --overwrite           overwrite existing settings
+      --add                 add a traffic shaping rule in addition to existing
+                            rules.
 
     Traffic Control:
       --direction {outgoing,incoming}
                             the direction of network communication that impose
-                            traffic control. ``incoming`` requires linux kernel
+                            traffic control. ``incoming`` requires Linux kernel
                             version 2.6.20 or later. (default = ``outgoing``)
       --rate BANDWIDTH_RATE
-                            network bandwidth rate [K|M|G bps]
+                            network bandwidth rate [K|M|G bit per second]
       --delay NETWORK_LATENCY
                             round trip network delay [ms]. the valid range is 0 to
-                            10000. (default=0)
+                            3600000. (default=0)
       --delay-distro LATENCY_DISTRO_MS
                             distribution of network latency becomes X +- Y [ms]
-                            (normal distribution), with this option. (X: value of
-                            --delay option, Y: value of --delay-dist option)
+                            (normal distribution). Here X is the value of --delay
+                            option and Y is the value of --delay-dist option).
                             network latency distribution will be uniform without
                             this option.
       --loss PACKET_LOSS_RATE
@@ -48,5 +49,17 @@
                             packet corruption rate [%]. the valid range is 0 to
                             100. packet corruption means single bit error at a
                             random offset in the packet. (default=0)
-      --network NETWORK     Target IP address/network of traffic control
-      --port PORT           port number of traffic control
+      --network NETWORK     target IP address/network to control traffic
+      --port PORT           target port number to control traffic.
+      --shaping-algo {tbf,htb}
+                            shaping algorithm. defaults to htb (recommended).
+
+    Routing:
+      --iptables            use iptables to traffic shaping.
+      --src-network SRC_NETWORK
+                            set traffic shaping rule to a specific packets that
+                            routed from --src-network to --network. This option
+                            required to execute with the --iptables option. the
+                            shaping rule only affect to outgoing packets (no
+                            effect to if you execute with "--direction incoming"
+                            option)

--- a/docs/pages/usage/tcshow/tcshow_help.rst
+++ b/docs/pages/usage/tcshow/tcshow_help.rst
@@ -3,8 +3,7 @@
 
 ::
 
-    usage: tcshow [-h] [--version] [--logging] [--stacktrace] [--debug | --quiet]
-                  --device DEVICE
+    usage: tcdel [-h] [--version] [--debug | --quiet] --device DEVICE
 
 .. option:: tcshow command options
 
@@ -12,11 +11,18 @@
       -h, --help       show this help message and exit
       --version        show program's version number and exit
       --debug          for debug print.
-      --quiet          suppress output of execution log message.
+      --quiet          suppress execution log messages.
 
-    Miscellaneous:
-      --logging        output execution log to a file (tcshow.log).
-      --stacktrace     display stack trace when an error occurred.
+    Traffic Control:
+      --device DEVICE  network device name (e.g. eth0)
+    [/home/GitHubDesktop/tcconfig]# tcshow -h
+    usage: tcshow [-h] [--version] [--debug | --quiet] --device DEVICE
+
+    optional arguments:
+      -h, --help       show this help message and exit
+      --version        show program's version number and exit
+      --debug          for debug print.
+      --quiet          suppress execution log messages.
 
     Traffic Control:
       --device DEVICE  network device name (e.g. eth0)

--- a/packaging.sh
+++ b/packaging.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eu
+
+dist_dir="tcconfig_wheel"
+wheelhouse_dir_path=${dist_dir}/"wheelhouse"
+install_script_path=${dist_dir}/"install.sh"
+lancher_script="launcher.sh"
+
+
+# make wheelhouse ---
+python setup.py bdist_wheel --dist-dir ${dist_dir} --universal
+pip wheel -r requirements/requirements.txt --wheel-dir ${wheelhouse_dir_path}
+
+rm ${wheelhouse_dir_path}/Logbook-*.whl
+pip download Logbook --no-deps --dest ${wheelhouse_dir_path}
+
+
+# make an install script ---
+cat <<EOF > ${install_script_path}
+#!/bin/bash
+
+set -eu
+
+pip install --use-wheel --no-index --find-links=wheelhouse tcconfig-*.whl --upgrade
+EOF
+
+chmod +x ${install_script_path}
+
+
+# make an archive file ---
+tar cvf tcconfig_wheel.tar.gz tcconfig_wheel

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@ ipaddress
 logbook
 pyparsing
 six
-subprocrunner>=0.4.4
+subprocrunner>=0.4.6
 voluptuous

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,3 +1,4 @@
-pingparsing>=0.3.1
+allpairspy
+pingparsing>=0.4.0
 pytest
 tox

--- a/tcconfig/_common.py
+++ b/tcconfig/_common.py
@@ -54,12 +54,12 @@ def sanitize_network(network):
         return ANYWHERE_NETWORK
 
     try:
-        ipaddress.IPv4Address(network)
+        ipaddress.IPv4Address(six.text_type(network))
         return network + "/32"
     except ipaddress.AddressValueError:
         pass
 
-    ipaddress.IPv4Network(network)  # validate network str
+    ipaddress.IPv4Network(six.text_type(network))  # validate network str
 
     return network
 

--- a/tcconfig/_common.py
+++ b/tcconfig/_common.py
@@ -54,12 +54,12 @@ def sanitize_network(network):
         return ANYWHERE_NETWORK
 
     try:
-        ipaddress.IPv4Address(six.u(network))
+        ipaddress.IPv4Address(network)
         return network + "/32"
     except ipaddress.AddressValueError:
         pass
 
-    ipaddress.IPv4Network(six.u(network))  # validate network str
+    ipaddress.IPv4Network(network)  # validate network str
 
     return network
 

--- a/tcconfig/_common.py
+++ b/tcconfig/_common.py
@@ -5,11 +5,13 @@
 """
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import contextlib
 
 import dataproperty
 import logbook
 import six
+import subprocrunner as spr
 
 from ._const import ANYWHERE_NETWORK
 from ._error import NetworkInterfaceNotFoundError
@@ -63,8 +65,6 @@ def sanitize_network(network):
 
 
 def run_command_helper(command, error_regexp, message, exception=None):
-    import subprocrunner as spr
-
     if logger.level != logbook.DEBUG:
         spr.set_logger(is_enable=False)
 
@@ -89,3 +89,11 @@ def run_command_helper(command, error_regexp, message, exception=None):
         raise exception(command)
 
     return proc.returncode
+
+
+def run_tc_show(subcommand, device):
+    runner = spr.SubprocessRunner(
+        "tc {:s} show dev {:s}".format(subcommand, device))
+    runner.run()
+
+    return runner.stdout

--- a/tcconfig/_const.py
+++ b/tcconfig/_const.py
@@ -11,3 +11,20 @@ from __future__ import unicode_literals
 VERSION = "0.7.0-alpha-4"
 
 ANYWHERE_NETWORK = "0.0.0.0/0"
+
+
+class Tc(object):
+
+    class Subcommand(object):
+        CLASS = "class"
+        FILTER = "filter"
+        QDISC = "qdisc"
+        SHOW = "show"
+
+    class Param(object):
+        CLASS_ID = "classid"
+        FLOW_ID = "flowid"
+        HANDLE = "handle"
+        NETWORK = "network"
+        PARENT = "parent"
+        PORT = "port"

--- a/tcconfig/_const.py
+++ b/tcconfig/_const.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 
-VERSION = "0.7.0-alpha-4"
+VERSION = "0.7.0"
 
 ANYWHERE_NETWORK = "0.0.0.0/0"
 

--- a/tcconfig/_iptables.py
+++ b/tcconfig/_iptables.py
@@ -14,6 +14,7 @@ from subprocrunner import SubprocessRunner
 
 from ._const import ANYWHERE_NETWORK
 from ._common import sanitize_network
+from ._logger import logger
 from ._split_line_list import split_line_list
 
 
@@ -128,6 +129,7 @@ class IptablesMangleController(object):
     __RE_CHAIN_NAME = re.compile(
         "{:s}|{:s}|{:s}".format(*VALID_CHAIN_LIST))
     __MAX_MARK_ID = 0xffffffff
+    __MARK_ID_OFFSET = 100
 
     enable = True
 
@@ -152,7 +154,9 @@ class IptablesMangleController(object):
     @classmethod
     def get_unique_mark_id(cls):
         mark_id_list = [mangle.mark_id for mangle in cls.parse()]
-        unique_mark_id = 1
+        logger.debug("mangle mark list: {}".format(mark_id_list))
+
+        unique_mark_id = 1 + cls.__MARK_ID_OFFSET
         while unique_mark_id < cls.__MAX_MARK_ID:
             if unique_mark_id not in mark_id_list:
                 return unique_mark_id

--- a/tcconfig/_iptables.py
+++ b/tcconfig/_iptables.py
@@ -9,6 +9,7 @@ import re
 
 import dataproperty
 from dataproperty import IntegerType
+from mbstrdecoder import MultiByteStrDecoder
 from subprocrunner import SubprocessRunner
 
 from ._const import ANYWHERE_NETWORK
@@ -146,7 +147,7 @@ class IptablesMangleController(object):
         if proc.run() != 0:
             raise RuntimeError(str(proc.stderr))
 
-        return proc.stdout
+        return MultiByteStrDecoder(proc.stdout).unicode_str
 
     @classmethod
     def get_unique_mark_id(cls):

--- a/tcconfig/_iptables.py
+++ b/tcconfig/_iptables.py
@@ -9,7 +9,6 @@ import re
 
 import dataproperty
 from dataproperty import IntegerType
-from mbstrdecoder import MultiByteStrDecoder
 from subprocrunner import SubprocessRunner
 
 from ._const import ANYWHERE_NETWORK
@@ -141,15 +140,15 @@ class IptablesMangleController(object):
         for mangle in cls.parse():
             proc = SubprocessRunner(mangle.to_delete_command())
             if proc.run() != 0:
-                raise RuntimeError(str(proc.stderr))
+                raise RuntimeError(proc.stderr)
 
     @classmethod
     def get_iptables(cls):
         proc = SubprocessRunner("iptables -t mangle --line-numbers -L")
         if proc.run() != 0:
-            raise RuntimeError(str(proc.stderr))
+            raise RuntimeError(proc.stderr)
 
-        return MultiByteStrDecoder(proc.stdout).unicode_str
+        return proc.stdout
 
     @classmethod
     def get_unique_mark_id(cls):

--- a/tcconfig/parser.py
+++ b/tcconfig/parser.py
@@ -236,3 +236,55 @@ class TcQdiscParser(object):
                 self.__parsed_param[parse_param_name] = result
         except pp.ParseException:
             pass
+
+
+class TcClassParser(object):
+
+    class Pattern(object):
+        CLASS_ID = "[0-9a-z:]+"
+        RATE = "[0-9]+[KMGT]?"
+
+    class Key(object):
+        CLASS_ID = "classid"
+        RATE = "rate"
+
+    def __init__(self):
+        self.__clear()
+
+    def parse(self, text):
+        for line in text.splitlines():
+            self.__clear()
+
+            if dataproperty.is_empty_string(line):
+                continue
+
+            line = _to_unicode(line.lstrip())
+
+            self.__parse_classid(line)
+            self.__parse_rate(line)
+
+            yield self.__parsed_param
+
+    def __clear(self):
+        self.__parsed_param = {}
+
+    def __parse_classid(self, line):
+        self.__parsed_param[self.Key.CLASS_ID] = None
+        tag = "class htb "
+
+        match = re.search("{:s}{:s}".format(tag, self.Pattern.CLASS_ID), line)
+        if match is None:
+            return
+
+        self.__parsed_param[self.Key.CLASS_ID] = re.search(
+            self.Pattern.CLASS_ID, match.group().lstrip(tag)).group()
+
+    def __parse_rate(self, line):
+        self.__parsed_param[self.Key.RATE] = None
+
+        match = re.search("rate {:s}".format(self.Pattern.RATE), line)
+        if match is None:
+            return
+
+        self.__parsed_param[self.Key.RATE] = re.search(
+            self.Pattern.RATE, match.group()).group()

--- a/tcconfig/shaper/_interface.py
+++ b/tcconfig/shaper/_interface.py
@@ -55,8 +55,6 @@ class ShaperInterface(object):
 
 class AbstractShaper(ShaperInterface):
 
-    __FILTER_IPTABLES_MARK_ID_OFFSET = 100
-
     @property
     def tc_device(self):
         return "{:s}".format(self._tc_obj.get_tc_device())
@@ -153,9 +151,7 @@ class AbstractShaper(ShaperInterface):
         raise ValueError("unknown direction: {}".format(self.direction))
 
     def _get_unique_mangle_mark_id(self):
-        mark_id = (
-            IptablesMangleController.get_unique_mark_id() +
-            self.__FILTER_IPTABLES_MARK_ID_OFFSET)
+        mark_id = IptablesMangleController.get_unique_mark_id()
 
         self.__add_mangle_mark(mark_id)
 

--- a/tcconfig/shaper/_interface.py
+++ b/tcconfig/shaper/_interface.py
@@ -18,7 +18,6 @@ from .._iptables import (
     IptablesMangleController,
     IptablesMangleMark
 )
-from .._logger import logger
 from .._traffic_direction import TrafficDirection
 
 
@@ -59,8 +58,12 @@ class AbstractShaper(ShaperInterface):
     __FILTER_IPTABLES_MARK_ID_OFFSET = 100
 
     @property
+    def tc_device(self):
+        return "{:s}".format(self._tc_obj.get_tc_device())
+
+    @property
     def dev(self):
-        return "dev {:s}".format(self._tc_obj.get_tc_device())
+        return "dev {:s}".format(self.tc_device)
 
     def __init__(self, tc_obj):
         self._tc_obj = tc_obj

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -144,7 +144,7 @@ class HtbShaper(AbstractShaper):
             self.add_filter()
 
     def __get_unique_qdisc_minor_id(self):
-        runner = SubprocessRunner("tc class show {:s}".format(self.dev))
+        runner = SubprocessRunner("tc class show dev {:s}".format(self.dev))
         runner.run()
         exist_class_item_list = re.findall(
             "class htb {}".format(
@@ -175,7 +175,7 @@ class HtbShaper(AbstractShaper):
         return next_minor_id
 
     def __get_unique_netem_major_id(self):
-        runner = SubprocessRunner("tc qdisc show {:s}".format(self.dev))
+        runner = SubprocessRunner("tc qdisc show dev {:s}".format(self.dev))
         runner.run()
         exist_netem_item_list = re.findall(
             "qdisc [a-z]+ [a-z0-9]+", runner.stdout, re.MULTILINE)

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -14,7 +14,9 @@ from subprocrunner import SubprocessRunner
 from .._common import (
     logging_context,
     run_command_helper,
+    run_tc_show,
 )
+from .._const import Tc
 from .._converter import Humanreadable
 from .._error import (
     TcAlreadyExist,
@@ -144,12 +146,10 @@ class HtbShaper(AbstractShaper):
             self.add_filter()
 
     def __get_unique_qdisc_minor_id(self):
-        runner = SubprocessRunner("tc class show {:s}".format(self.dev))
-        runner.run()
         exist_class_item_list = re.findall(
             "class htb {}".format(
                 self._tc_obj.qdisc_major_id_str) + "[\:][0-9]+",
-            runner.stdout,
+            run_tc_show(Tc.Subcommand.CLASS, self.tc_device),
             re.MULTILINE)
 
         exist_class_minor_id_list = []
@@ -175,10 +175,10 @@ class HtbShaper(AbstractShaper):
         return next_minor_id
 
     def __get_unique_netem_major_id(self):
-        runner = SubprocessRunner("tc qdisc show {:s}".format(self.dev))
-        runner.run()
         exist_netem_item_list = re.findall(
-            "qdisc [a-z]+ [a-z0-9]+", runner.stdout, re.MULTILINE)
+            "qdisc [a-z]+ [a-z0-9]+",
+            run_tc_show(Tc.Subcommand.QDISC, self.tc_device),
+            re.MULTILINE)
 
         exist_netem_major_id_list = []
         for netem_item in exist_netem_item_list:

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 import re
 
 import dataproperty
-from subprocrunner import SubprocessRunner
 
 from .._common import (
     logging_context,

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -144,7 +144,7 @@ class HtbShaper(AbstractShaper):
             self.add_filter()
 
     def __get_unique_qdisc_minor_id(self):
-        runner = SubprocessRunner("tc class show dev {:s}".format(self.dev))
+        runner = SubprocessRunner("tc class show {:s}".format(self.dev))
         runner.run()
         exist_class_item_list = re.findall(
             "class htb {}".format(
@@ -175,7 +175,7 @@ class HtbShaper(AbstractShaper):
         return next_minor_id
 
     def __get_unique_netem_major_id(self):
-        runner = SubprocessRunner("tc qdisc show dev {:s}".format(self.dev))
+        runner = SubprocessRunner("tc qdisc show {:s}".format(self.dev))
         runner.run()
         exist_netem_item_list = re.findall(
             "qdisc [a-z]+ [a-z0-9]+", runner.stdout, re.MULTILINE)

--- a/tcconfig/tcdel.py
+++ b/tcconfig/tcdel.py
@@ -52,6 +52,8 @@ def main():
         return 1
 
     tc = TrafficControl(options.device)
+    if options.log_level == logbook.INFO:
+        subprocrunner.set_log_level(logbook.ERROR)
 
     try:
         return tc.delete_tc()

--- a/tcconfig/tcset.py
+++ b/tcconfig/tcset.py
@@ -58,7 +58,7 @@ def parse_option():
         "--direction", choices=TrafficDirection.LIST,
         default=TrafficDirection.OUTGOING,
         help="""the direction of network communication that impose traffic control.
-        ``incoming`` requires linux kernel version 2.6.20 or later.
+        ``incoming`` requires Linux kernel version 2.6.20 or later.
         (default = ``%(default)s``)
         """)
     group.add_argument(
@@ -75,8 +75,8 @@ def parse_option():
         "--delay-distro", dest="latency_distro_ms", type=float, default=0,
         help="""
         distribution of network latency becomes X +- Y [ms]
-        (normal distribution), with this option.
-        (X: value of --delay option, Y: value of --delay-dist option)
+        (normal distribution). Here X is the value of --delay option and
+        Y is the value of --delay-dist option).
         network latency distribution will be uniform without this option.
         """)
     group.add_argument(
@@ -98,26 +98,26 @@ def parse_option():
             TrafficControl.MAX_CORRUPTION_RATE))
     group.add_argument(
         "--network",
-        help="Target IP address/network of traffic control")
+        help="target IP address/network to control traffic")
     group.add_argument(
         "--port", type=int,
-        help="port number of traffic control")
+        help="target port number to control traffic.")
 
-    group = parser.parser.add_argument_group("Prototype")
+    group = parser.parser.add_argument_group("Experimental Prototype")
     group.add_argument(
         "--add", dest="is_add_shaper", action="store_true", default=False,
-        help="")
+        help="add a traffic shaping rule in addition to existing rules.")
     group.add_argument(
         "--iptables", dest="is_enable_iptables",
         action="store_true", default=False,
-        help="[experimental] use iptables to filter network")
+        help="use iptables to traffic shaping.")
     group.add_argument(
         "--src-network",
         help="[require iptables]")
     group.add_argument(
         "--shaping-algo", dest="shaping_algorithm",
         choices=["tbf", "htb"], default="htb",
-        help="shaping algorithm (default=%(default)s)")
+        help="shaping algorithm (default=%(default)s).")
 
     return parser.parser.parse_args()
 

--- a/tcconfig/tcset.py
+++ b/tcconfig/tcset.py
@@ -268,7 +268,8 @@ def main():
         return 1
 
     if options.overwrite:
-        set_log_level(logbook.ERROR)
+        if options.log_level == logbook.INFO:
+            set_log_level(logbook.ERROR)
 
         try:
             tc.delete_tc()

--- a/tcconfig/tcshow.py
+++ b/tcconfig/tcshow.py
@@ -24,7 +24,10 @@ from .parser import (
     TcClassParser,
 )
 from ._argparse_wrapper import ArgparseWrapper
-from ._common import verify_network_interface
+from ._common import (
+    verify_network_interface,
+    run_tc_show,
+)
 from ._const import (
     VERSION,
     Tc,
@@ -169,31 +172,23 @@ class TcShapingRuleParser(object):
 
         return shaping_rule_mapping
 
-    @staticmethod
-    def __execute_tc_show(subcommand, device):
-        runner = SubprocessRunner(
-            "tc {:s} show dev {:s}".format(subcommand, device))
-        runner.run()
-
-        return runner.stdout
-
     def __parse_tc_qdisc(self, device):
         param_list = list(TcQdiscParser().parse(
-            self.__execute_tc_show(Tc.Subcommand.QDISC, device)))
+            run_tc_show(Tc.Subcommand.QDISC, device)))
         logger.debug("tc qdisc parse result: {}".format(param_list))
 
         return param_list
 
     def __parse_tc_filter(self, device):
         param_list = list(TcFilterParser().parse_filter(
-            self.__execute_tc_show(Tc.Subcommand.FILTER, device)))
+            run_tc_show(Tc.Subcommand.FILTER, device)))
         logger.debug("tc filter parse result: {}".format(param_list))
 
         return param_list
 
     def __parse_tc_class(self, device):
         param_list = list(TcClassParser().parse(
-            self.__execute_tc_show(Tc.Subcommand.CLASS, device)))
+            run_tc_show(Tc.Subcommand.CLASS, device)))
         logger.debug("tc class parse result: {}".format(param_list))
 
         return param_list

--- a/tcconfig/traffic_control.py
+++ b/tcconfig/traffic_control.py
@@ -76,7 +76,10 @@ class TrafficControl(object):
     EXISTS_MSG_TEMPLATE = (
         "{:s} "
         "execute with --overwrite option if you want to overwrite "
-        "the existing settings.")
+        "the existing rules."
+        "execute with --add option if you want to add a new rule in addition "
+        "to the existing rules."
+    )
 
     @property
     def ifb_device(self):

--- a/tcconfig/traffic_control.py
+++ b/tcconfig/traffic_control.py
@@ -177,9 +177,19 @@ class TrafficControl(object):
     def validate(self):
         verify_network_interface(self.__device)
         self.__validate_netem_parameter()
+        self.__validate_src_network()
+
         self.__network = sanitize_network(self.network)
         self.__src_network = sanitize_network(self.src_network)
         self.__validate_port()
+
+    def __validate_src_network(self):
+        if dataproperty.is_empty_string(self.src_network):
+            return
+
+        if not self.is_enable_iptables:
+            raise InvalidParameterError(
+                "--iptables option will be required to use --src-network option")
 
     def validate_bandwidth_rate(self):
         if not dataproperty.FloatType(self.bandwidth_rate).is_type():

--- a/tcconfig/traffic_control.py
+++ b/tcconfig/traffic_control.py
@@ -62,7 +62,7 @@ class TrafficControl(object):
     MAX_PACKET_LOSS_RATE = 100  # [%]
 
     MIN_LATENCY_MS = 0  # [millisecond]
-    MAX_LATENCY_MS = 10000  # [millisecond]
+    MAX_LATENCY_MS = 3600000  # [millisecond]
 
     MIN_CORRUPTION_RATE = 0  # [%]
     MAX_CORRUPTION_RATE = 100  # [%]

--- a/test/common.py
+++ b/test/common.py
@@ -21,7 +21,7 @@ def is_invalid_param(rate, delay, loss, corrupt):
     ])
 
     try:
-        Humanreadable(rate, kilo_size=1000).to_no_prefix_value(rate)
+        Humanreadable(rate, kilo_size=1000).to_no_prefix_value()
     except ValueError:
         pass
     else:

--- a/test/test_iptables.py
+++ b/test/test_iptables.py
@@ -4,6 +4,7 @@
 .. codeauthor:: Tsuyoshi Hombashi <gogogo.vm@gmail.com>
 """
 
+from __future__ import unicode_literals
 import random
 
 import pytest
@@ -269,7 +270,7 @@ class Test_IptablesMangleController_parse(object):
         for lhs_mangle, rhs_mangle in zip(
                 IptablesMangleController.parse(), reverse_mangle_mark_list):
 
-            print("lhs: {:s}".format(lhs_mangle))
-            print("rhs: {:s}".format(rhs_mangle))
+            print("lhs: {}".format(lhs_mangle))
+            print("rhs: {}".format(rhs_mangle))
 
             assert lhs_mangle == rhs_mangle

--- a/test/test_iptables.py
+++ b/test/test_iptables.py
@@ -201,10 +201,12 @@ class Test_IptablesMangleController_get_unique_mark_id(object):
         for i in range(5):
             mark_id = IptablesMangleController.get_unique_mark_id()
 
-            assert mark_id == (i + 1)
+            assert mark_id == (i + 101)
+
             mangle_mark = IptablesMangleMark(
                 mark_id=mark_id, source=_DEF_SRC, destination=_DEF_DST,
                 chain=random.choice(VALID_CHAIN_LIST))
+
             assert IptablesMangleController.add(mangle_mark) == 0
 
 

--- a/test/test_tcconfig.py
+++ b/test/test_tcconfig.py
@@ -102,7 +102,7 @@ class Test_tcconfig(object):
     @pytest.mark.parametrize(
         [
             "rate", "delay", "delay_distro", "loss", "corrupt",
-            "direction", "network", "port", "overwrite",
+            "direction", "network", "port", "overwrite", "is_enable_iptables",
         ],
         [
             opt_list
@@ -121,7 +121,7 @@ class Test_tcconfig(object):
         ])
     def test_smoke(
             self, device_value, rate, delay, delay_distro, loss, corrupt,
-            direction, network, port, overwrite):
+            direction, network, port, overwrite, is_enable_iptables):
 
         if device_value is None:
             pytest.skip("device is empty")
@@ -135,7 +135,7 @@ class Test_tcconfig(object):
             "tcset",
             device_option,
             rate, delay, delay_distro, loss, corrupt,
-            direction, network, port, overwrite,
+            direction, network, port, overwrite, is_enable_iptables,
         ])).run() == 0
 
         SubprocessRunner("tcdel {:s}".format(device_option)).run()

--- a/test/test_tcconfig.py
+++ b/test/test_tcconfig.py
@@ -5,8 +5,8 @@
 """
 
 from __future__ import division
-import itertools
 
+from allpairspy import AllPairs
 import dataproperty
 import pytest
 from subprocrunner import SubprocessRunner
@@ -16,8 +16,15 @@ SKIP_TEST = False
 
 
 @pytest.fixture
-def device_option(request):
+def device_value(request):
     return request.config.getoption("--device")
+
+
+def is_valid_combination(row):
+    if all([dataproperty.is_empty_string(param) for param in row]):
+        return False
+
+    return True
 
 
 def is_invalid_param(rate, delay, loss, corrupt):
@@ -71,7 +78,12 @@ class NormalTestValue(object):
     ]
     OVERWRITE_LIST = [
         "",
+        "--add",
         "--overwrite",
+    ]
+    IPTABLES_LIST = [
+        "",
+        "--iptables",
     ]
 
 
@@ -94,7 +106,7 @@ class Test_tcconfig(object):
         ],
         [
             opt_list
-            for opt_list in itertools.product(
+            for opt_list in AllPairs([
                 NormalTestValue.RATE_LIST,
                 NormalTestValue.DELAY_LIST,
                 NormalTestValue.DELAY_DISTRO_LIST,
@@ -103,24 +115,27 @@ class Test_tcconfig(object):
                 NormalTestValue.DIRECTION_LIST,
                 NormalTestValue.NETWORK_LIST,
                 NormalTestValue.PORT_LIST,
-                NormalTestValue.OVERWRITE_LIST)
+                NormalTestValue.OVERWRITE_LIST,
+                NormalTestValue.IPTABLES_LIST,
+            ], n=3, filter_func=is_valid_combination)
         ])
     def test_smoke(
-            self, device_option, rate, delay, delay_distro, loss, corrupt,
+            self, device_value, rate, delay, delay_distro, loss, corrupt,
             direction, network, port, overwrite):
 
-        if device_option is None:
-            pytest.skip("device option is null")
+        if device_value is None:
+            pytest.skip("device is empty")
 
         if is_invalid_param(rate, delay, loss, corrupt):
             pytest.skip("skip null parameters")
 
-        command = " ".join([
+        device_option = "--device {}".format(device_value)
+
+        assert SubprocessRunner(" ".join([
             "tcset",
-            "--device " + device_option,
+            device_option,
             rate, delay, delay_distro, loss, corrupt,
             direction, network, port, overwrite,
-        ])
-        assert SubprocessRunner(command).run() == 0
+        ])).run() == 0
 
-        SubprocessRunner("tcdel --device " + device_option).run()
+        SubprocessRunner("tcdel {:s}".format(device_option)).run()

--- a/test/test_tcconfig.py
+++ b/test/test_tcconfig.py
@@ -5,6 +5,7 @@
 """
 
 from __future__ import division
+from __future__ import unicode_literals
 
 from allpairspy import AllPairs
 import dataproperty
@@ -130,6 +131,8 @@ class Test_tcconfig(object):
             pytest.skip("skip null parameters")
 
         device_option = "--device {}".format(device_value)
+
+        SubprocessRunner("tcdel {:s}".format(device_option)).run()
 
         assert SubprocessRunner(" ".join([
             "tcset",

--- a/test/test_tcset_config_file.py
+++ b/test/test_tcset_config_file.py
@@ -13,7 +13,7 @@ from subprocrunner import SubprocessRunner
 
 
 @pytest.fixture
-def device_option(request):
+def device_value(request):
     return request.config.getoption("--device")
 
 
@@ -24,41 +24,43 @@ class Test_tcconfig(object):
         ["", 0],
         ["--overwrite", 0],
     ])
-    def test_config_file(self, tmpdir, device_option, overwrite, expected):
-        if device_option is None:
+    def test_config_file(self, tmpdir, device_value, overwrite, expected):
+        if device_value is None:
             pytest.skip("device option is null")
 
         p = tmpdir.join("tcconfig.json")
-        config = "{" + '"{:s}"'.format(device_option) + ": {" + """
+        config = "{" + '"{:s}"'.format(device_value) + ": {" + """
         "outgoing": {
             "network=192.168.0.10/32, port=8080": {
                 "delay": "10.0",
                 "loss": "0.01",
                 "rate": "250K",
                 "delay-distro": "2.0"
-            },
-            "network=0.0.0.0/0": {}
+            }
         },
         "incoming": {
             "network=192.168.10.0/24": {
                 "corrupt": "0.02",
                 "rate": "1500K"
-            },
-            "network=0.0.0.0/0": {}
+            }
         }
     }
 }
 """
         p.write(config)
 
-        SubprocessRunner("tcdel --device {}".format(device_option)).run()
+        device_option = "--device {:s}".format(device_value)
+
+        SubprocessRunner("tcdel {:s}".format(device_option)).run()
         command = " ".join(["tcset -f ", str(p), overwrite])
         assert SubprocessRunner(command).run() == expected
 
-        runner = SubprocessRunner("tcshow --device {}".format(device_option))
+        runner = SubprocessRunner("tcshow {:s}".format(device_option))
         runner.run()
 
-        print(runner.stdout)
+        print("[expected]\n{}".format(config))
+        print("\n[actual]\n{}".format(runner.stdout))
+
         assert json.loads(runner.stdout) == json.loads(config)
 
-        SubprocessRunner("tcdel --device {}".format(device_option)).run()
+        SubprocessRunner("tcdel {:s}".format(device_option)).run()

--- a/test/test_tcshow.py
+++ b/test/test_tcshow.py
@@ -11,7 +11,7 @@ from subprocrunner import SubprocessRunner
 
 
 @pytest.fixture
-def device_option(request):
+def device_value(request):
     return request.config.getoption("--device")
 
 
@@ -23,61 +23,91 @@ class Test_tcshow(object):
     """
 
     @pytest.mark.xfail
-    def test_normal(self, device_option):
-        if device_option is None:
+    def test_normal(self, device_value):
+        if device_value is None:
             pytest.skip("device option is null")
 
-        SubprocessRunner("tcdel --device " + device_option).run()
+        device_option = "--device {:s}".format(device_value)
+        tcdel_command = "tcdel {:s}".format(device_option)
 
-        command = " ".join([
+        assert SubprocessRunner(" ".join([
             "tcset",
-            "--device", device_option,
+            device_option,
             "--delay", "10",
             "--delay-distro", "2",
             "--loss", "0.01",
-            "--rate", "0.25M",
+            "--rate", "0.25K",
             "--network", "192.168.0.10",
             "--port", "8080",
-        ])
-        assert SubprocessRunner(command).run() == 0
+            "--overwrite",
+        ])).run() == 0
 
-        command = " ".join([
+        assert SubprocessRunner(" ".join([
             "tcset",
-            "--device", device_option,
+            device_option,
             "--delay", "1",
-            "--loss", "0.02",
+            "--loss", "1",
+            "--rate", "100M",
+            "--network", "192.168.1.0/24",
+            "--add",
+        ])).run() == 0
+
+        assert SubprocessRunner(" ".join([
+            "tcset",
+            device_option,
+            "--delay", "10",
+            "--delay-distro", "2",
             "--rate", "500K",
             "--direction", "incoming",
-        ])
-        assert SubprocessRunner(command).run() == 0
+        ])).run() == 0
 
-        command = " ".join([
-            "tcshow",
-            "--device", device_option,
-        ])
-        runner = SubprocessRunner(command)
+        assert SubprocessRunner(" ".join([
+            "tcset",
+            device_option,
+            "--delay", "1",
+            "--loss", "0.02",
+            "--rate", "0.1M",
+            "--network", "192.168.11.0/24",
+            "--port", "80",
+            "--direction", "incoming",
+            "--add",
+        ])).run() == 0
+
+        runner = SubprocessRunner("tcshow {:s}".format(device_option))
         runner.run()
 
-        expected = "{" + '"{:s}"'.format(device_option) + ": {" + """
+        expected = "{" + '"{:s}"'.format(device_value) + ": {" + """
         "outgoing": {
-            "network=192.168.0.10/32, port=8080": {
+            "network=192.168.1.0/24": {
+                "delay": "1.0",
+                "loss": "1",
+                "rate": "100M"
+            },
+           "network=192.168.0.10/32, port=8080": {
                 "delay": "10.0",
                 "loss": "0.01",
-                "rate": "250K",
+                "rate": "248",
                 "delay-distro": "2.0"
-            },
-            "network=0.0.0.0/0": {}
+            }
         },
         "incoming": {
-            "network=0.0.0.0/0": {
+            "network=192.168.11.0/24, port=80": {
                 "delay": "1.0",
                 "loss": "0.02",
+                "rate": "100K"
+            },
+            "network=0.0.0.0/0": {
+                "delay": "10.0",
+                "delay-distro": "2.0",
                 "rate": "500K"
             }
         }
     }
 }"""
 
+        print("[expected]\n{}".format(expected))
+        print("[actual]\n{}".format(runner.stdout))
+
         assert json.loads(runner.stdout) == json.loads(expected)
 
-        SubprocessRunner("tcdel --device " + device_option).run()
+        SubprocessRunner(tcdel_command).run()

--- a/test/test_traffic_control.py
+++ b/test/test_traffic_control.py
@@ -122,7 +122,7 @@ class Test_TrafficControl_validate(object):
 
     @pytest.mark.parametrize(["value", "expected"], [
         [{"latency_ms": -1}, ValueError],
-        [{"latency_ms": 10001}, ValueError],
+        [{"latency_ms": 3600001}, ValueError],
 
         [{"latency_distro_ms": -1}, ValueError],
         [{"latency_distro_ms": 10001}, ValueError],

--- a/test/test_traffic_control.py
+++ b/test/test_traffic_control.py
@@ -6,6 +6,7 @@
 
 import itertools
 
+from allpairspy import AllPairs
 from dataproperty import FloatType
 import pytest
 
@@ -24,31 +25,30 @@ def device_option(request):
 
 @pytest.mark.parametrize(["value"], [
     ["".join(opt_list)]
-    for opt_list in itertools.product(
+    for opt_list in AllPairs([
         ["0.1", "1", "2147483647"],
         [
             "k", " k", "K", " K",
             "m", " m", "M", " M",
             "g", " g", "G", " G",
         ]
-    )
+    ])
 ])
 def test_TrafficControl_validate_bandwidth_rate_normal(value):
     tc_obj = TrafficControl("dummy", bandwidth_rate=value)
-    print(tc_obj.bandwidth_rate)
     tc_obj.validate_bandwidth_rate()
 
 
 @pytest.mark.parametrize(["value", "expected"], [
     ["".join(opt_list), ValueError]
-    for opt_list in itertools.product(
+    for opt_list in AllPairs([
         ["0.1", "1", "2147483647"],
         [
             "kb", "kbps", "KB",
             "mb", "mbps", "MB",
             "gb", "gbps", "GB",
         ]
-    )
+    ])
 ])
 def test_TrafficControl_validate_bandwidth_rate_exception_1(value, expected):
     tc_obj = TrafficControl("dummy", bandwidth_rate=value)
@@ -78,7 +78,7 @@ class Test_TrafficControl_validate(object):
         ],
         [
             opt_list
-            for opt_list in itertools.product(
+            for opt_list in AllPairs([
                 [None, "", "100K", "0.5M", "0.1G"],  # rate
                 [TrafficDirection.OUTGOING],
                 [None, 0, 10000],  # delay
@@ -92,7 +92,7 @@ class Test_TrafficControl_validate(object):
                     "192.168.0.1/32", "192.168.0.0/24"
                 ],  # network
                 [None, 0, 65535],  # port
-            )
+            ], n=3)
         ])
     def test_normal(
             self, device_option, rate, direction, delay, delay_distro, loss,


### PR DESCRIPTION
- #30: Filter routes support. Thanks to @JonathanLennox
- #39: Allow 100% packet loss/corruption settings. Thanks to @pdavies.
- #43: Multiple rules support. Thanks to @konetzed 
  - Add `--add` option
- Change default shaping algorithm from tbf to htb
- Python 3.6 support
- Improve log messages
- Bug fixes