### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,7 @@ Dependency python packages are automatically installed during
 - `pyparsing <https://pyparsing.wikispaces.com/>`__
 - `six <https://pypi.python.org/pypi/six/>`__
 - `subprocrunner <https://github.com/thombashi/subprocrunner>`__
+- `typepy <https://github.com/thombashi/typepy>`__
 - `voluptuous <https://github.com/alecthomas/voluptuous>`__
 
 Optional

--- a/docs/make_readme.py
+++ b/docs/make_readme.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import os.path
 import sys
 
+from path import Path
 import readmemaker
 
 
@@ -20,16 +21,18 @@ def write_examples(maker):
     maker.set_indent_level(0)
     maker.write_chapter("Usage")
 
+    usage_root = Path(os.path.join("pages", "usage"))
+
     maker.inc_indent_level()
     maker.write_chapter("Set traffic control (``tcset`` command)")
-    maker.write_example_file(os.path.join("tcset", "description.txt"))
-    maker.write_example_file(os.path.join("tcset", "basic_usage.rst"))
+    maker.write_file(usage_root.joinpath("tcset", "description.txt"))
+    maker.write_file(usage_root.joinpath("tcset", "basic_usage.rst"))
 
-    maker.write_example_file(os.path.join("tcdel", "header.rst"))
-    maker.write_example_file(os.path.join("tcdel", "usage.rst"))
+    maker.write_file(usage_root.joinpath("tcdel", "header.rst"))
+    maker.write_file(usage_root.joinpath("tcdel", "usage.rst"))
 
-    maker.write_example_file(os.path.join("tcshow", "header.rst"))
-    maker.write_example_file(os.path.join("tcshow", "usage.rst"))
+    maker.write_file(usage_root.joinpath("tcshow", "header.rst"))
+    maker.write_file(usage_root.joinpath("tcshow", "usage.rst"))
 
     maker.write_chapter("For more information")
     maker.write_line_list([

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -45,6 +45,7 @@ Dependency python packages are automatically installed during
 - `pyparsing <https://pyparsing.wikispaces.com/>`__
 - `six <https://pypi.python.org/pypi/six/>`__
 - `subprocrunner <https://github.com/thombashi/subprocrunner>`__
+- `typepy <https://github.com/thombashi/typepy>`__
 - `voluptuous <https://github.com/alecthomas/voluptuous>`__
 
 Optional

--- a/docs/pages/links.rst
+++ b/docs/pages/links.rst
@@ -1,11 +1,8 @@
 Links
 =====
 
-- pip: tool for installing python packages
-    - https://pip.pypa.io/en/stable/
-- GitHub repository
-    - https://github.com/thombashi/tcconfig
-- Issue tracker
-    - https://github.com/thombashi/tcconfig/issues
-- PyPI
-    - https://pypi.python.org/pypi/tcconfig
+
+- `pip: A tool for installing python packages <https://pip.pypa.io/en/stable/>`__
+- `GitHub repository <https://github.com/thombashi/tcconfig>`__
+- `Issue tracker <https://github.com/thombashi/tcconfig/issues>`__
+- `PyPI <https://pypi.python.org/pypi/tcconfig>`__

--- a/requirements/docs_requirements.txt
+++ b/requirements/docs_requirements.txt
@@ -1,3 +1,3 @@
-readmemaker
+readmemaker>=0.3.0
 sphinx_rtd_theme
 Sphinx

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,6 @@ ipaddress
 logbook
 pyparsing
 six
-subprocrunner>=0.4.9
+subprocrunner>=0.4.10
+typepy>=0.0.2
 voluptuous

--- a/tcconfig/_common.py
+++ b/tcconfig/_common.py
@@ -6,11 +6,13 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import contextlib
 
-import dataproperty
 import logbook
 import six
+import typepy
+
 import subprocrunner as spr
 
 from ._const import ANYWHERE_NETWORK
@@ -47,7 +49,7 @@ def sanitize_network(network):
 
     import ipaddress
 
-    if dataproperty.is_empty_string(network):
+    if typepy.is_null_string(network):
         return ""
 
     if network.lower() == "anywhere":
@@ -82,7 +84,7 @@ def run_command_helper(command, error_regexp, message, exception=None):
         logger.error(proc.stderr)
         return proc.returncode
 
-    if dataproperty.is_not_empty_string(message):
+    if typepy.is_not_null_string(message):
         logger.notice(message)
 
     if exception is not None:

--- a/tcconfig/_const.py
+++ b/tcconfig/_const.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 VERSION = "0.7.1-alpha"
 
 ANYWHERE_NETWORK = "0.0.0.0/0"
+KILO_SIZE = 1000
 
 
 class Tc(object):

--- a/tcconfig/_const.py
+++ b/tcconfig/_const.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 
-VERSION = "0.7.1-alpha"
+VERSION = "0.7.1"
 
 ANYWHERE_NETWORK = "0.0.0.0/0"
 KILO_SIZE = 1000

--- a/tcconfig/_converter.py
+++ b/tcconfig/_converter.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 import re
 
 import dataproperty

--- a/tcconfig/_converter.py
+++ b/tcconfig/_converter.py
@@ -9,7 +9,7 @@ from __future__ import division
 from __future__ import unicode_literals
 import re
 
-import dataproperty
+import typepy
 
 
 class Humanreadable(object):
@@ -38,7 +38,7 @@ class Humanreadable(object):
         :raises ValueError:
         """
 
-        if dataproperty.is_empty_string(self.__readable_size):
+        if typepy.is_null_string(self.__readable_size):
             raise ValueError("readable_size is empty")
 
         size = self.__readable_size[:-1]

--- a/tcconfig/_iptables.py
+++ b/tcconfig/_iptables.py
@@ -9,9 +9,9 @@ from __future__ import unicode_literals
 
 import re
 
-from dataproperty import IntegerType
-import dataproperty
 from subprocrunner import SubprocessRunner
+import typepy
+from typepy.type import Integer
 
 from ._common import sanitize_network
 from ._const import ANYWHERE_NETWORK
@@ -74,7 +74,7 @@ class IptablesMangleMark(object):
     def __repr__(self, *args, **kwargs):
         str_list = []
 
-        if IntegerType(self.line_number).is_type():
+        if Integer(self.line_number).is_type():
             str_list.append("line-num={}".format(self.line_number))
 
         str_list.extend([
@@ -88,7 +88,7 @@ class IptablesMangleMark(object):
         return ", ".join(str_list)
 
     def to_append_command(self):
-        IntegerType(self.mark_id).validate()
+        Integer(self.mark_id).validate()
 
         command_item_list = [
             "iptables -A {:s} -t mangle -j MARK".format(self.chain),
@@ -96,8 +96,8 @@ class IptablesMangleMark(object):
         ]
 
         if any([
-            dataproperty.is_not_empty_string(self.protocol),
-            IntegerType(self.protocol).is_type(),
+            typepy.is_not_null_string(self.protocol),
+            Integer(self.protocol).is_type(),
         ]):
             command_item_list.append("-p {}".format(self.protocol))
         if self.__is_valid_srcdst(self.source):
@@ -110,7 +110,7 @@ class IptablesMangleMark(object):
         return " ".join(command_item_list)
 
     def to_delete_command(self):
-        IntegerType(self.line_number).validate()
+        Integer(self.line_number).validate()
 
         return "iptables -t mangle -D {:s} {}".format(
             self.chain, self.line_number)
@@ -118,7 +118,7 @@ class IptablesMangleMark(object):
     @staticmethod
     def __is_valid_srcdst(srcdst):
         return (
-            dataproperty.is_not_empty_string(srcdst) and
+            typepy.is_not_null_string(srcdst) and
             srcdst != ANYWHERE_NETWORK
         )
 

--- a/tcconfig/_iptables.py
+++ b/tcconfig/_iptables.py
@@ -5,14 +5,16 @@
 """
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import re
 
-import dataproperty
 from dataproperty import IntegerType
+import dataproperty
 from subprocrunner import SubprocessRunner
 
-from ._const import ANYWHERE_NETWORK
 from ._common import sanitize_network
+from ._const import ANYWHERE_NETWORK
 from ._logger import logger
 from ._split_line_list import split_line_list
 

--- a/tcconfig/_traffic_direction.py
+++ b/tcconfig/_traffic_direction.py
@@ -5,6 +5,7 @@
 """
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 
 class TrafficDirection(object):

--- a/tcconfig/parser.py
+++ b/tcconfig/parser.py
@@ -6,10 +6,12 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import copy
 import re
 
-import dataproperty
+import typepy
+
 import pyparsing as pp
 
 from ._const import Tc
@@ -75,13 +77,13 @@ class TcFilterParser(object):
     def parse_filter(self, text):
         self.__clear()
 
-        if dataproperty.is_empty_string(text):
+        if typepy.is_null_string(text):
             return []
 
         filter_data_matrix = []
 
         for line in text.splitlines():
-            if dataproperty.is_empty_string(line):
+            if typepy.is_null_string(line):
                 continue
 
             try:
@@ -122,7 +124,7 @@ class TcFilterParser(object):
         return filter_data_matrix
 
     def parse_incoming_device(self, text):
-        if dataproperty.is_empty_string(text):
+        if typepy.is_null_string(text):
             return None
 
         match = re.search(
@@ -195,13 +197,13 @@ class TcQdiscParser(object):
         self.__clear()
 
     def parse(self, text):
-        if dataproperty.is_empty_string(text):
+        if typepy.is_null_string(text):
             raise ValueError("empty text")
 
         text = text.strip()
 
         for line in text.splitlines():
-            if dataproperty.is_empty_string(line):
+            if typepy.is_null_string(line):
                 continue
 
             line = _to_unicode(line.lstrip())
@@ -246,7 +248,7 @@ class TcQdiscParser(object):
 
         try:
             result = pattern.parseString(_to_unicode(line))[-1]
-            if dataproperty.is_not_empty_string(result):
+            if typepy.is_not_null_string(result):
                 self.__parsed_param[parse_param_name] = result
         except pp.ParseException:
             pass
@@ -259,7 +261,7 @@ class TcQdiscParser(object):
 
         try:
             result = pattern.parseString(line)[-1]
-            if dataproperty.is_not_empty_string(result):
+            if typepy.is_not_null_string(result):
                 result = result.rstrip("bit")
                 self.__parsed_param[parse_param_name] = result
         except pp.ParseException:
@@ -283,7 +285,7 @@ class TcClassParser(object):
         for line in text.splitlines():
             self.__clear()
 
-            if dataproperty.is_empty_string(line):
+            if typepy.is_null_string(line):
                 continue
 
             line = _to_unicode(line.lstrip())

--- a/tcconfig/shaper/_interface.py
+++ b/tcconfig/shaper/_interface.py
@@ -6,11 +6,12 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import abc
 
-import dataproperty
 import six
 from subprocrunner import SubprocessRunner
+import typepy
 
 from .._common import run_command_helper
 from .._const import ANYWHERE_NETWORK
@@ -114,7 +115,7 @@ class AbstractShaper(ShaperInterface):
             command_list.append(
                 "handle {:d} fw".format(self._get_unique_mangle_mark_id()))
         else:
-            if dataproperty.is_empty_string(self._tc_obj.network):
+            if typepy.is_null_string(self._tc_obj.network):
                 network = ANYWHERE_NETWORK
             else:
                 network = self._tc_obj.network
@@ -163,7 +164,7 @@ class AbstractShaper(ShaperInterface):
 
         if self._tc_obj.direction == TrafficDirection.OUTGOING:
             dst_network = self._tc_obj.network
-            if dataproperty.is_empty_string(self._tc_obj.src_network):
+            if typepy.is_null_string(self._tc_obj.src_network):
                 chain = "OUTPUT"
             else:
                 src_network = self._tc_obj.src_network

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -85,14 +85,14 @@ class HtbShaper(AbstractShaper):
         classid = "{:s}:{:d}".format(
             self._tc_obj.qdisc_major_id_str,
             self.get_qdisc_minor_id())
-        no_limit_bits = Humanreadable(
+        no_limit_kbits = Humanreadable(
             self.__NO_LIMIT, kilo_size=1000).to_kilo_value()
 
         try:
             self._tc_obj.validate_bandwidth_rate()
             kbits = self._tc_obj.bandwidth_rate
         except EmptyParameterError:
-            kbits = no_limit_bits
+            kbits = no_limit_kbits
 
         command_list = [
             "tc class add",
@@ -104,7 +104,7 @@ class HtbShaper(AbstractShaper):
             "ceil {:f}Kbit".format(kbits),
         ]
 
-        if kbits != no_limit_bits:
+        if kbits != no_limit_kbits:
             command_list.extend([
                 "burst {:f}KB".format(kbits / (10 * 8)),
                 "cburst {:f}KB".format(kbits / (10 * 8)),

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -90,9 +90,9 @@ class HtbShaper(AbstractShaper):
 
         try:
             self._tc_obj.validate_bandwidth_rate()
-            kbitps = self._tc_obj.bandwidth_rate
+            kbits = self._tc_obj.bandwidth_rate
         except EmptyParameterError:
-            kbitps = no_limit_bits
+            kbits = no_limit_bits
 
         command_list = [
             "tc class add",
@@ -100,14 +100,14 @@ class HtbShaper(AbstractShaper):
             "parent {:s}".format(parent),
             "classid {:s}".format(classid),
             self.algorithm_name,
-            "rate {:f}Kbit".format(kbitps),
-            "ceil {:f}Kbit".format(kbitps),
+            "rate {:f}Kbit".format(kbits),
+            "ceil {:f}Kbit".format(kbits),
         ]
 
-        if kbitps != no_limit_bits:
+        if kbits != no_limit_bits:
             command_list.extend([
-                "burst {:f}KB".format(kbitps / (10 * 8)),
-                "cburst {:f}KB".format(kbitps / (10 * 8)),
+                "burst {:f}KB".format(kbits / (10 * 8)),
+                "cburst {:f}KB".format(kbits / (10 * 8)),
             ])
 
         command = " ".join(command_list)

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -15,7 +15,10 @@ from .._common import (
     run_command_helper,
     run_tc_show,
 )
-from .._const import Tc
+from .._const import (
+    KILO_SIZE,
+    Tc,
+)
 from .._converter import Humanreadable
 from .._error import (
     TcAlreadyExist,
@@ -61,11 +64,12 @@ class HtbShaper(AbstractShaper):
         # http://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git/commit/?id=8334bb325d5178483a3063c5f06858b46d993dc7
 
         iproute2_upper_kbits = Humanreadable(
-            "32G", kilo_size=1000).to_kilo_value()
+            "32G", kilo_size=KILO_SIZE).to_kilo_value()
 
         try:
             with open("/sys/class/net/{:s}/speed".format(self.tc_device)) as f:
-                return min(int(f.read().strip()) * 1000, iproute2_upper_kbits)
+                return min(
+                    int(f.read().strip()) * KILO_SIZE, iproute2_upper_kbits)
         except IOError:
             return iproute2_upper_kbits
 

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import re
 
-import dataproperty
+import typepy
 
 from .._common import (
     logging_context,
@@ -169,11 +169,11 @@ class HtbShaper(AbstractShaper):
 
         exist_class_minor_id_list = []
         for class_item in exist_class_item_list:
-            inttype = dataproperty.IntegerType(class_item.split(":")[1])
-            if not inttype.is_convertible_type():
+            try:
+                exist_class_minor_id_list.append(
+                    typepy.type.Integer(class_item.split(":")[1]).convert())
+            except typepy.TypeConversionError:
                 continue
-
-            exist_class_minor_id_list.append(inttype.convert())
 
         logger.debug("existing class list with {:s}: {}".format(
             self.dev, exist_class_item_list))

--- a/tcconfig/shaper/tbf.py
+++ b/tcconfig/shaper/tbf.py
@@ -7,8 +7,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import dataproperty
 from subprocrunner import SubprocessRunner
+import typepy
 
 from .._common import (
     logging_context,
@@ -122,8 +122,8 @@ class TbfShaper(AbstractShaper):
             return 0
 
         if all([
-            dataproperty.is_empty_string(self._tc_obj.network),
-            not dataproperty.IntegerType(self._tc_obj.port).is_type(),
+            typepy.is_null_string(self._tc_obj.network),
+            not typepy.type.Integer(self._tc_obj.port).is_type(),
         ]):
             flowid = "{:s}:{:d}".format(
                 self._tc_obj.qdisc_major_id_str,

--- a/tcconfig/tcset.py
+++ b/tcconfig/tcset.py
@@ -6,15 +6,16 @@
 """
 
 from __future__ import absolute_import
+
 import sys
 
-import dataproperty
 import logbook
-import pyparsing as pp
 import six
 import subprocrunner
+import typepy
 
-from .traffic_control import TrafficControl
+import pyparsing as pp
+
 from ._argparse_wrapper import ArgparseWrapper
 from ._const import (
     VERSION,
@@ -30,6 +31,7 @@ from ._logger import (
     set_log_level,
 )
 from ._traffic_direction import TrafficDirection
+from .traffic_control import TrafficControl
 
 
 logbook.StderrHandler(
@@ -249,7 +251,7 @@ def main():
     except subprocrunner.CommandNotFoundError as e:
         logger.error(str(e))
 
-    if dataproperty.is_not_empty_string(options.config_file):
+    if typepy.is_not_null_string(options.config_file):
         return set_tc_from_file(logger, options.config_file, options.overwrite)
 
     tc = TrafficControl(

--- a/tcconfig/tcshow.py
+++ b/tcconfig/tcshow.py
@@ -7,22 +7,18 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import copy
 import json
 import sys
 
-import dataproperty
-from dataproperty import IntegerType
 import logbook
 import six
-import subprocrunner
 from subprocrunner import SubprocessRunner
+import subprocrunner
+import typepy
+from typepy.type import Integer
 
-from .parser import (
-    TcFilterParser,
-    TcQdiscParser,
-    TcClassParser,
-)
 from ._argparse_wrapper import ArgparseWrapper
 from ._common import (
     verify_network_interface,
@@ -40,6 +36,11 @@ from ._logger import (
     set_log_level,
 )
 from ._traffic_direction import TrafficDirection
+from .parser import (
+    TcFilterParser,
+    TcQdiscParser,
+    TcClassParser,
+)
 
 
 logbook.StderrHandler(
@@ -90,7 +91,7 @@ class TcShapingRuleParser(object):
 
         if Tc.Param.HANDLE in filter_param:
             handle = filter_param.get(Tc.Param.HANDLE)
-            IntegerType(handle).validate()
+            Integer(handle).validate()
             handle = int(handle)
 
             for mangle in IptablesMangleController.parse():
@@ -98,7 +99,7 @@ class TcShapingRuleParser(object):
                     continue
 
                 key_item_list.append(network_format.format(mangle.destination))
-                if dataproperty.is_not_empty_string(mangle.source):
+                if typepy.is_not_null_string(mangle.source):
                     key_item_list.append("source={:s}".format(mangle.source))
                 key_item_list.append("protocol={}".format(mangle.protocol))
 
@@ -107,17 +108,17 @@ class TcShapingRuleParser(object):
                 raise ValueError("mangle mark not found: {}".format(mangle))
         else:
             network = filter_param.get(Tc.Param.NETWORK)
-            if dataproperty.is_not_empty_string(network):
+            if typepy.is_not_null_string(network):
                 key_item_list.append(network_format.format(network))
 
             port = filter_param.get(Tc.Param.PORT)
-            if IntegerType(port).is_type():
+            if Integer(port).is_type():
                 key_item_list.append(port_format.format(port))
 
         return ", ".join(key_item_list)
 
     def __get_shaping_rule(self, device):
-        if dataproperty.is_empty_string(device):
+        if typepy.is_null_string(device):
             return {}
 
         class_param_list = self.__parse_tc_class(device)
@@ -132,7 +133,7 @@ class TcShapingRuleParser(object):
             shaping_rule = {}
 
             filter_key = self.__get_filter_key(filter_param)
-            if dataproperty.is_empty_string(filter_key):
+            if typepy.is_null_string(filter_key):
                 logger.debug("empty filter key: {}".format(filter_param))
                 continue
 

--- a/tcconfig/traffic_control.py
+++ b/tcconfig/traffic_control.py
@@ -6,13 +6,14 @@
 
 from __future__ import absolute_import
 from __future__ import division
+
 import re
 
-import dataproperty
 from dataproperty import (
     DataProperty,
     FloatType,
 )
+import dataproperty
 import six
 from subprocrunner import SubprocessRunner
 
@@ -22,6 +23,7 @@ from ._common import (
     verify_network_interface,
     run_command_helper,
 )
+from ._const import KILO_SIZE
 from ._converter import Humanreadable
 from ._error import (
     NetworkInterfaceNotFoundError,
@@ -166,7 +168,7 @@ class TrafficControl(object):
         # bandwidth string [G/M/K bit per second]
         try:
             self.__bandwidth_rate = Humanreadable(
-                bandwidth_rate, kilo_size=1000).to_kilo_value()
+                bandwidth_rate, kilo_size=KILO_SIZE).to_kilo_value()
         except ValueError:
             self.__bandwidth_rate = None
 

--- a/tcconfig/traffic_control.py
+++ b/tcconfig/traffic_control.py
@@ -9,13 +9,11 @@ from __future__ import division
 
 import re
 
-from dataproperty import (
-    DataProperty,
-    FloatType,
-)
-import dataproperty
+from dataproperty import DataProperty
 import six
 from subprocrunner import SubprocessRunner
+import typepy
+from typepy.type import RealNumber
 
 from ._common import (
     logging_context,
@@ -169,7 +167,7 @@ class TrafficControl(object):
         try:
             self.__bandwidth_rate = Humanreadable(
                 bandwidth_rate, kilo_size=KILO_SIZE).to_kilo_value()
-        except ValueError:
+        except (TypeError, ValueError):
             self.__bandwidth_rate = None
 
         IptablesMangleController.enable = is_enable_iptables
@@ -186,7 +184,7 @@ class TrafficControl(object):
         self.__validate_port()
 
     def __validate_src_network(self):
-        if dataproperty.is_empty_string(self.src_network):
+        if typepy.is_null_string(self.src_network):
             return
 
         if not self.is_enable_iptables:
@@ -194,7 +192,7 @@ class TrafficControl(object):
                 "--iptables option will be required to use --src-network option")
 
     def validate_bandwidth_rate(self):
-        if not dataproperty.FloatType(self.bandwidth_rate).is_type():
+        if not RealNumber(self.bandwidth_rate).is_type():
             raise EmptyParameterError("bandwidth_rate is empty")
 
         if self.bandwidth_rate <= 0:
@@ -300,7 +298,7 @@ class TrafficControl(object):
         ]
 
         if all([
-            not FloatType(
+            not RealNumber(
                 netem_param_value).is_type() or netem_param_value == 0
             for netem_param_value in netem_param_value_list
         ]):
@@ -322,7 +320,7 @@ class TrafficControl(object):
         if self.direction != TrafficDirection.INCOMING:
             return 0
 
-        if dataproperty.is_empty_string(self.ifb_device):
+        if typepy.is_null_string(self.ifb_device):
             return -1
 
         return_code = 0

--- a/test/common.py
+++ b/test/common.py
@@ -4,7 +4,7 @@
 .. codeauthor:: Tsuyoshi Hombashi <gogogo.vm@gmail.com>
 """
 
-from dataproperty import FloatType
+from typepy.type import RealNumber
 
 from tcconfig._converter import Humanreadable
 
@@ -17,7 +17,7 @@ def is_invalid_param(rate, delay, loss, corrupt):
     ]
 
     is_invalid = all([
-        not FloatType(param).is_type() or param == 0 for param in params
+        not RealNumber(param).is_type() or param == 0 for param in params
     ])
 
     try:

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -61,8 +61,8 @@ class Test_to_no_prefix_value:
     @pytest.mark.parametrize(["value", "kilo_size", "exception"], [
         ["", 1000, ValueError],
         [None, 1000, ValueError],
-        [True, 1000, ValueError],
-        [float("nan"), 1000, ValueError],
+        [True, 1000, TypeError],
+        [float("nan"), 1000, TypeError],
         ["a", 1000, ValueError],
         ["1k0 ", 1000, ValueError],
         ["10kb", 1000, ValueError],

--- a/test/test_tcconfig.py
+++ b/test/test_tcconfig.py
@@ -7,10 +7,11 @@
 from __future__ import division
 from __future__ import unicode_literals
 
-from allpairspy import AllPairs
-import dataproperty
 import pytest
 from subprocrunner import SubprocessRunner
+import typepy
+
+from allpairspy import AllPairs
 
 
 SKIP_TEST = False
@@ -22,7 +23,7 @@ def device_value(request):
 
 
 def is_valid_combination(row):
-    if all([dataproperty.is_empty_string(param) for param in row]):
+    if all([typepy.is_null_string(param) for param in row]):
         return False
 
     return True
@@ -37,7 +38,7 @@ def is_invalid_param(rate, delay, loss, corrupt):
     ]
 
     return all([
-        dataproperty.is_empty_string(param) for param in params
+        typepy.is_null_string(param) for param in params
     ])
 
 

--- a/test/test_tcset_one.py
+++ b/test/test_tcset_one.py
@@ -5,12 +5,13 @@
 """
 
 from __future__ import division
+
 import platform
 
-import dataproperty
 import pingparsing
 import pytest
 from subprocrunner import SubprocessRunner
+import typepy
 
 
 WAIT_TIME = 5  # [sec]
@@ -61,7 +62,7 @@ class Test_tcset_one_network(object):
         if device_option is None:
             pytest.skip("device option is null")
 
-        if dataproperty.is_empty_string(dst_host_option):
+        if typepy.is_null_string(dst_host_option):
             pytest.skip("destination host is null")
 
         SubprocessRunner("tcdel --device " + device_option).run()
@@ -98,7 +99,7 @@ class Test_tcset_one_network(object):
     def test_const_latency_distro(
             self, device_option, dst_host_option, transmitter, pingparser,
             delay, delay_distro):
-        if dataproperty.is_empty_string(dst_host_option):
+        if typepy.is_null_string(dst_host_option):
             # alternative to pytest.mark.skipif
             return
 
@@ -142,7 +143,7 @@ class Test_tcset_one_network(object):
     def test_const_packet_loss(
             self, device_option, dst_host_option, transmitter, pingparser,
             option, value):
-        if dataproperty.is_empty_string(dst_host_option):
+        if typepy.is_null_string(dst_host_option):
             # alternative to pytest.mark.skipif
             return
 

--- a/test/test_tcset_two.py
+++ b/test/test_tcset_two.py
@@ -6,10 +6,10 @@
 
 from __future__ import division
 
-import dataproperty
 import pingparsing
 import pytest
 from subprocrunner import SubprocessRunner
+import typepy
 
 
 WAIT_TIME = 5  # [sec]
@@ -63,8 +63,8 @@ class Test_tcset_two_network(object):
             pytest.skip("device option is null")
 
         if any([
-            dataproperty.is_empty_string(dst_host_option),
-            dataproperty.is_empty_string(dst_host_ex_option),
+            typepy.is_null_string(dst_host_option),
+            typepy.is_null_string(dst_host_ex_option),
         ]):
             pytest.skip("destination host is null")
 

--- a/test/test_traffic_control.py
+++ b/test/test_traffic_control.py
@@ -6,12 +6,12 @@
 
 import itertools
 
-from allpairspy import AllPairs
-from dataproperty import FloatType
 import pytest
 
-from tcconfig.traffic_control import TrafficControl
+from allpairspy import AllPairs
 from tcconfig._traffic_direction import TrafficDirection
+from tcconfig.traffic_control import TrafficControl
+
 from .common import is_invalid_param
 
 


### PR DESCRIPTION
Fix failed to execute `tcset` when `iproute2` version is older than `3.14.0`