### PR TITLE
Don't return a failure if we try to delete a qdisc handle that doesn't exist

### DIFF
--- a/tcconfig/traffic_control.py
+++ b/tcconfig/traffic_control.py
@@ -458,6 +458,8 @@ class TrafficControl:
                 return False
             elif re.search("Cannot find device", runner.stderr):
                 raise NetworkInterfaceNotFoundError(target=self.device)
+            elif re.search("Error: Cannot delete qdisc with handle of zero.", runner.stderr):
+                return True
             else:
                 is_success = runner.returncode == 0
                 if is_success:


### PR DESCRIPTION
Before:
```
$ tcdel veth1 --all && echo $?
[WARNING] command='/sbin/tc qdisc del dev veth1 root', returncode=2, stderr='Error: Cannot delete qdisc with handle of zero.\n'
[WARNING] no qdisc to delete for the incoming device.
1
```
After:
```
$ tcdel veth1 --all && echo $?
[WARNING] command='/sbin/tc qdisc del dev veth1 root', returncode=2, stderr='Error: Cannot delete qdisc with handle of zero.\n'
[WARNING] no qdisc to delete for the incoming device.
0
```