### PR TITLE
Update bug_report.md template to work with new envinfopy syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,8 @@ Steps to reproduce the behavior:
 Please execute the following command and past the output:
 
 ```
-pip install envinfopy
-python -m envinfopy --packages "tcconfig,docker,SimpleSQLite" --format markdown
+pip install envinfopy[markdown]
+python -m envinfopy tcconfig docker SimpleSQLite --format markdown
 ```
 
 and complete the following information:


### PR DESCRIPTION
This is the required syntax of envinfopy, per envinfopy readme (https://github.com/thombashi/envinfopy/blob/master/README.rst#cli-usage) and my own testing. The old syntax does not work. Thanks!