### PR TITLE
Set htb burst and cburst size to the minimum useful size.

### DIFF
--- a/tcconfig/_netem_param.py
+++ b/tcconfig/_netem_param.py
@@ -40,6 +40,10 @@ class NetemParameter:
     def bandwidth_rate(self):
         return self.__bandwidth_rate
 
+    @property
+    def mtu(self):
+        return self.__mtu
+
     def __init__(
         self,
         device,
@@ -52,6 +56,7 @@ class NetemParameter:
         corruption_rate=None,
         reordering_rate=None,
         packet_limit_count=None,
+        mtu=None,
     ):
         self.__device = device
 
@@ -61,6 +66,7 @@ class NetemParameter:
         self.__corruption_rate = convert_rate_to_f(corruption_rate)  # [%]
         self.__reordering_rate = convert_rate_to_f(reordering_rate)  # [%]
         self.__packet_limit_count = convert_rate_to_f(packet_limit_count)  # [COUNT]
+        self.__mtu = mtu  # [bytes]
 
         self.__latency_time = None
         if latency_time:
@@ -116,6 +122,7 @@ class NetemParameter:
             self.__corruption_rate,
             self.__reordering_rate,
             self.__packet_limit_count,
+            self.__mtu,
         ]
         if self.__bandwidth_rate:
             netem_param_values.append(self.__bandwidth_rate.kilo_bps)

--- a/tcconfig/_netem_param.py
+++ b/tcconfig/_netem_param.py
@@ -44,6 +44,10 @@ class NetemParameter:
     def mtu(self):
         return self.__mtu
 
+    @property
+    def burst(self):
+        return self.__burst
+
     def __init__(
         self,
         device,
@@ -57,6 +61,7 @@ class NetemParameter:
         reordering_rate=None,
         packet_limit_count=None,
         mtu=None,
+        burst=None,
     ):
         self.__device = device
 
@@ -67,6 +72,7 @@ class NetemParameter:
         self.__reordering_rate = convert_rate_to_f(reordering_rate)  # [%]
         self.__packet_limit_count = convert_rate_to_f(packet_limit_count)  # [COUNT]
         self.__mtu = mtu  # [bytes]
+        self.__burst = burst  # [bytes]
 
         self.__latency_time = None
         if latency_time:
@@ -123,6 +129,7 @@ class NetemParameter:
             self.__reordering_rate,
             self.__packet_limit_count,
             self.__mtu,
+            self.__burst,
         ]
         if self.__bandwidth_rate:
             netem_param_values.append(self.__bandwidth_rate.kilo_bps)

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -4,6 +4,7 @@
 
 import errno
 import re
+from bisect import bisect_left
 from typing import List
 
 import typepy
@@ -141,11 +142,12 @@ class HtbShaper(AbstractShaper):
             mtu = 1600
             rate = bandwidth.byte_per_sec
             desired_burst = int(rate / get_hz() + mtu)
-            burst = desired_burst
-            while True:
-                if calc_xmitsize_true(rate, calc_xmittime_bug(rate, burst)) >= desired_burst:
-                    break
-                burst += 1
+
+            burst = bisect_left(
+                range(1 << 32),
+                True,
+                key=lambda b: calc_xmitsize_true(rate, calc_xmittime_bug(rate, b)) >= desired_burst,
+            )
 
             command_item_list.extend(
                 [

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -73,9 +73,9 @@ def adjusted_burst_size(desired_burst: int, rate: int) -> int:
     else:
         adjusted_burst = desired_burst
         while adjusted_burst < (1 << 32):
-            if calc_xmitsize_true(rate, calc_xmittime_bug(rate, burst)) >= desired_burst:
+            if calc_xmitsize_true(rate, calc_xmittime_bug(rate, adjusted_burst)) >= desired_burst:
                 return adjusted_burst
-            burst += 1
+            adjusted_burst += 1
         return adjusted_burst
 
 

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -20,20 +20,20 @@ from ._interface import AbstractShaper
 
 # Emulation of tc's buggy time2tick implementation, which
 # rounds to int twice
-def time2tick_bug(time):
+def time2tick_bug(time: int) -> int:
     return int(int(time) * tick_in_usec)
 
 
 # An accurate implementation of tick2time (unlike tc's), not rounding.
-def tick2time_true(tick):
+def tick2time_true(tick: float) -> float:
     return tick / tick_in_usec
 
 
-def calc_xmittime_bug(rate, size):
+def calc_xmittime_bug(rate: int, size: int) -> int:
     return int(time2tick_bug(TIME_UNITS_PER_SEC * (float(size) / rate)))
 
 
-def calc_xmitsize_true(rate, ticks):
+def calc_xmitsize_true(rate: int, ticks: int) -> float:
     return (float(rate) * tick2time_true(ticks)) / TIME_UNITS_PER_SEC
 
 

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -172,9 +172,14 @@ class HtbShaper(AbstractShaper):
             f"ceil {bandwidth.kilo_bps}Kbit",
         ]
 
+        mtu = self._tc_obj.netem_param.mtu
+        if mtu:
+            command_item_list.extend([f"mtu {mtu:d}"])
+
         # TODO: check whether tc is from iproute2 version 6.15 or later, and if so bypass this code.
         if bandwidth != upper_limit_rate:
-            mtu = 1600
+            if not mtu:
+                mtu = 1600  # Default size in tc
             rate = bandwidth.byte_per_sec
             desired_burst = desired_burst_size(rate, mtu)
             burst = adjusted_burst_size(desired_burst, rate)

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -7,6 +7,7 @@ import re
 from typing import List
 
 import typepy
+from pyroute2.netlink.rtnl.tcmsg.common import TIME_UNITS_PER_SEC, get_hz, tick_in_usec
 
 from .._common import is_execute_tc_command, logging_context, run_command_helper
 from .._const import ShapingAlgorithm, TcSubCommand
@@ -15,26 +16,25 @@ from .._logger import logger
 from .._network import get_upper_limit_rate
 from .._tc_command_helper import run_tc_show
 from ._interface import AbstractShaper
-from pyroute2.netlink.rtnl.tcmsg.common import  (
-    get_hz,
-    tick_in_usec,
-    TIME_UNITS_PER_SEC
-)
+
 
 # Emulation of tc's buggy time2tick implementation, which
 # rounds to int twice
 def time2tick_bug(time):
     return int(int(time) * tick_in_usec)
 
+
 # An accurate implementation of tick2time (unlike tc's), not rounding.
 def tick2time_true(tick):
     return tick / tick_in_usec
 
+
 def calc_xmittime_bug(rate, size):
     return int(time2tick_bug(TIME_UNITS_PER_SEC * (float(size) / rate)))
 
+
 def calc_xmitsize_true(rate, ticks):
-    return (float(rate)*tick2time_true(ticks))/TIME_UNITS_PER_SEC
+    return (float(rate) * tick2time_true(ticks)) / TIME_UNITS_PER_SEC
 
 
 class HtbShaper(AbstractShaper):
@@ -134,7 +134,7 @@ class HtbShaper(AbstractShaper):
         if bandwidth != upper_limit_rate:
             # This sets the burst/cburst values to the default tc tries to set,
             # but works around a bug in tc where values are rounded incorrectly.
-            
+
             # Note that "tc class show" will still show burst that are too small,
             # due to the inverse bug, but if you use "tc -r class show" you will see
             # the actual size of the cbuffer in bytes.

--- a/tcconfig/shaper/htb.py
+++ b/tcconfig/shaper/htb.py
@@ -15,6 +15,26 @@ from .._logger import logger
 from .._network import get_upper_limit_rate
 from .._tc_command_helper import run_tc_show
 from ._interface import AbstractShaper
+from pyroute2.netlink.rtnl.tcmsg.common import  (
+    get_hz,
+    tick_in_usec,
+    TIME_UNITS_PER_SEC
+)
+
+# Emulation of tc's buggy time2tick implementation, which
+# rounds to int twice
+def time2tick_bug(time):
+    return int(int(time) * tick_in_usec)
+
+# An accurate implementation of tick2time (unlike tc's), not rounding.
+def tick2time_true(tick):
+    return tick / tick_in_usec
+
+def calc_xmittime_bug(rate, size):
+    return int(time2tick_bug(TIME_UNITS_PER_SEC * (float(size) / rate)))
+
+def calc_xmitsize_true(rate, ticks):
+    return (float(rate)*tick2time_true(ticks))/TIME_UNITS_PER_SEC
 
 
 class HtbShaper(AbstractShaper):
@@ -112,10 +132,25 @@ class HtbShaper(AbstractShaper):
         ]
 
         if bandwidth != upper_limit_rate:
+            # This sets the burst/cburst values to the default tc tries to set,
+            # but works around a bug in tc where values are rounded incorrectly.
+            
+            # Note that "tc class show" will still show burst that are too small,
+            # due to the inverse bug, but if you use "tc -r class show" you will see
+            # the actual size of the cbuffer in bytes.
+            mtu = 1600
+            rate = bandwidth.byte_per_sec
+            desired_burst = int(rate / get_hz() + mtu)
+            burst = desired_burst
+            while True:
+                if calc_xmitsize_true(rate, calc_xmittime_bug(rate, burst)) >= desired_burst:
+                    break
+                burst += 1
+
             command_item_list.extend(
                 [
-                    f"burst {bandwidth.kilo_byte_per_sec}KB",
-                    f"cburst {bandwidth.kilo_byte_per_sec}KB",
+                    f"burst {burst}b",
+                    f"cburst {burst}b",
                 ]
             )
 

--- a/tcconfig/shaper/tbf.py
+++ b/tcconfig/shaper/tbf.py
@@ -81,20 +81,22 @@ class TbfShaper(AbstractShaper):
         if bandwidth is None:
             bandwidth = upper_limit_rate
 
-        command = " ".join(
-            [
-                base_command,
-                self._dev,
-                f"parent {parent:s}",
-                f"handle {handle:s}",
-                self.algorithm_name,
-                f"rate {bandwidth.kilo_bps}kbit",
-                "buffer {:d}".format(
-                    max(int(bandwidth.kilo_bps), self.__MIN_BUFFER_BYTE)
-                ),  # [byte]
-                "limit 10000",
-            ]
-        )
+        command_item_list = [
+            base_command,
+            self._dev,
+            f"parent {parent:s}",
+            f"handle {handle:s}",
+            self.algorithm_name,
+            f"rate {bandwidth.kilo_bps}kbit",
+            "buffer {:d}".format(max(int(bandwidth.kilo_bps), self.__MIN_BUFFER_BYTE)),  # [byte]
+            "limit 10000",
+        ]
+
+        mtu = self._tc_obj.netem_param.mtu
+        if mtu:
+            command_item_list.extend([f"mtu {mtu:d}"])
+
+        command = " ".join(command_item_list)
 
         run_command_helper(
             command,

--- a/tcconfig/tcset.py
+++ b/tcconfig/tcset.py
@@ -193,6 +193,12 @@ def get_arg_parser():
         default=False,
         help="use iptables for traffic control.",
     )
+    group.add_argument(
+        "--mtu",
+        dest="mtu",
+        type=int,
+        help="MTU size to assume for interface, if not tc's default.  Only used for certain calculations, not enforced.",
+    )
 
     group = parser.add_routing_group()
     group.add_argument(
@@ -267,8 +273,7 @@ class TcSetMain(Main):
                         [
                             "adding a shaping rule failed. a shaping rule for the same "
                             "network/port already exists. try to execute with:",
-                            "  (a) --overwrite option if you want to overwrite "
-                            "the existing rules.",
+                            "  (a) --overwrite option if you want to overwrite the existing rules.",
                             "  (b) --change option if you want to change "
                             "the existing rule parameters.",
                         ]
@@ -318,6 +323,7 @@ class TcSetMain(Main):
                 corruption_rate=options.corruption_rate,
                 reordering_rate=options.reordering_rate,
                 packet_limit_count=options.packet_limit_count,
+                mtu=options.mtu,
             ),
             dst_network=self._extract_dst_network(),
             exclude_dst_network=options.exclude_dst_network,

--- a/tcconfig/tcset.py
+++ b/tcconfig/tcset.py
@@ -199,6 +199,12 @@ def get_arg_parser():
         type=int,
         help="MTU size to assume for interface, if not tc's default.  Only used for certain calculations, not enforced.",
     )
+    group.add_argument(
+        "--burst",
+        dest="burst",
+        type=int,
+        help="burst size to use for traffic shaping (htb only).",
+    )
 
     group = parser.add_routing_group()
     group.add_argument(
@@ -324,6 +330,7 @@ class TcSetMain(Main):
                 reordering_rate=options.reordering_rate,
                 packet_limit_count=options.packet_limit_count,
                 mtu=options.mtu,
+                burst=options.burst,
             ),
             dst_network=self._extract_dst_network(),
             exclude_dst_network=options.exclude_dst_network,

--- a/test/test_burstsize.py
+++ b/test/test_burstsize.py
@@ -1,0 +1,41 @@
+"""
+.. codeauthor:: Jonathan Lennox <jonathan.lennox@8x8.com>
+"""
+
+import humanreadable as hr
+import pytest
+
+from tcconfig.shaper.htb import adjusted_burst_size, desired_burst_size
+
+
+@pytest.mark.parametrize(
+    ["rate_hr", "mtu", "expected"],
+    [
+        ("1Mbps", 1600, 1600),
+        ("1Gbps", 1600, 1600),
+        ("8Gbps", 1600, 1601),
+        ("80Gbps", 1600, 1610),
+        ("80Gbps", 9000, 9010),
+    ],
+)
+def test_desired_burst(rate_hr, mtu, expected):
+    rate = hr.BitsPerSecond(rate_hr).byte_per_sec
+    desired_burst = desired_burst_size(rate, mtu)
+    assert desired_burst == expected
+
+
+@pytest.mark.parametrize(
+    ["desired_burst", "rate_hr", "expected"],
+    [
+        (1600, "1Mbps", 1600),
+        (1600, "1Gbps", 1625),
+        (1600, "8Gbps", 2000),
+        (1610, "80Gbps", 10000),
+        (9010, "80Gbps", 10000),
+    ],
+)
+def test_adjusted_burst(monkeypatch, desired_burst, rate_hr, expected):
+    monkeypatch.setattr("tcconfig.shaper.htb.tick_in_usec", lambda: 15.625)
+    rate = hr.BitsPerSecond(rate_hr).byte_per_sec
+    adjusted_burst = adjusted_burst_size(desired_burst, rate)
+    assert adjusted_burst == expected

--- a/test/test_burstsize.py
+++ b/test/test_burstsize.py
@@ -5,7 +5,7 @@
 import humanreadable as hr
 import pytest
 
-from tcconfig.shaper.htb import adjusted_burst_size, desired_burst_size
+from tcconfig.shaper.htb import adjusted_burst_size, default_burst_size
 
 
 @pytest.mark.parametrize(
@@ -18,10 +18,10 @@ from tcconfig.shaper.htb import adjusted_burst_size, desired_burst_size
         ("80Gbps", 9000, 9010),
     ],
 )
-def test_desired_burst(rate_hr, mtu, expected):
+def test_default_burst(rate_hr, mtu, expected):
     rate = hr.BitsPerSecond(rate_hr).byte_per_sec
-    desired_burst = desired_burst_size(rate, mtu)
-    assert desired_burst == expected
+    default_burst = default_burst_size(rate, mtu)
+    assert default_burst == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This avoids problems where bursts of data can be sent at line speed rather than the limited speed.

Work around a bug in tc where burst values are triply-rounded.