### PR TITLE
Fix error when 2 or more veth pairs share the same peer_ifindex

### DIFF
--- a/tcconfig/_docker.py
+++ b/tcconfig/_docker.py
@@ -30,7 +30,7 @@ class IfIndex(Model):
     host = Text(not_null=True)
     ifindex = Integer(primary_key=True)
     ifname = Text(not_null=True)
-    peer_ifindex = Integer(not_null=True, unique=True)
+    peer_ifindex = Integer(not_null=True)
 
 
 class DockerClient:


### PR DESCRIPTION
Description:

This PR addresses an issue in the handling of Docker container network interfaces within tcconfig. Previously, the application enforced uniqueness on both ifindex and peer_ifindex for veth pairs. However, in Docker environments, while each veth pair is unique, the peer_ifindex can be the same across different containers. This incorrect assumption led to traffic control rules being applied only to the veth pair with the lexicographically first name, leaving others unconfigured. 

Changes Made:

Modified the in-memory simplesql database schema to remove the uniqueness constraint on peer_ifindex.

Related Issues:

Fixes thombashi/tcconfig#168, fixes thombashi/tcconfig#104
